### PR TITLE
replace xmlrpc implementation with phpxmlrpc/phpxmlrpc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,9 @@
 			"email": "glen@delfi.ee"
 		}
 	],
-	"repositories": [
-		{
-			"type": "composer",
-			"url": "https://eventum.github.io/composer/"
-		}
-	],
 	"require": {
-		"pear-pear.php.net/XML_RPC": "~1.5.5",
-		"php": ">=5.1.2"
+		"php": "^5.3.0 || ^7.0",
+		"phpxmlrpc/phpxmlrpc": "^4.1"
 	},
 	"autoload": {
 		"classmap": [ "src" ]

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -38,7 +38,7 @@ class ClientTest extends TestCase
         $method = 'system.listMethods';
 
         $client = new Eventum_RPC($url);
-        $methods = $client->__call($method, array());
+        $methods = $client->__call($method);
         $this->assertContains($method, $methods);
     }
 }


### PR DESCRIPTION
this adds support for php 7

the previous pear package, no longer worked with php7, out of several implementations from packagist i chose this one as it's similar to previous library and has minimal external dependencies:
- [php-xml](https://github.com/gggeek/phpxmlrpc/blob/4.1.1/composer.json#L9)

however, it may need curl extension to handle https:
- [php-curl](https://github.com/gggeek/phpxmlrpc/blob/4.1.1/composer.json#L22)